### PR TITLE
Xcode13対応時の変更をcherrypickする

### DIFF
--- a/KoarasSimonSaysGame.xcodeproj/project.pbxproj
+++ b/KoarasSimonSaysGame.xcodeproj/project.pbxproj
@@ -1084,7 +1084,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yui.KoalasSimonSaysGame;
 				PRODUCT_NAME = "旗ふりゲーム";
 				PROVISIONING_PROFILE_SPECIFIER = KoalasSimonSaysGame;
@@ -1111,7 +1111,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yui.KoalasSimonSaysGame;
 				PRODUCT_NAME = "旗ふりゲーム";
 				PROVISIONING_PROFILE_SPECIFIER = KoalasSimonSaysGame;
@@ -1223,7 +1223,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.yui.KoalasSimonSaysGame-DEVELOP";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = KoalasSimonSaysGameDev;
@@ -1248,7 +1248,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.yui.KoalasSimonSaysGame-DEVELOP";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = KoalasSimonSaysGameDev;

--- a/KoarasSimonSaysGame/Model/RankingModel.swift
+++ b/KoarasSimonSaysGame/Model/RankingModel.swift
@@ -19,8 +19,6 @@ protocol RankingModelProtocol {
 
 class RankingModel: RankingModelProtocol {
     
-    var defaultstore:Firestore!
-    
     func saveToUserDefaults(name: String, score: Int) {
         // 保存するメモ情報を配列にする 0: 名前, 1: スコア
         let rankingToSave: [String] = [name, "\(score)"]

--- a/KoarasSimonSaysGame/Pages/Menu/Menu.storyboard
+++ b/KoarasSimonSaysGame/Pages/Menu/Menu.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -150,7 +150,7 @@
                                     <constraint firstItem="YGP-Uv-ymN" firstAttribute="top" secondItem="KLO-Js-Bwu" secondAttribute="top" id="yRc-Fo-g6U"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="version 2.1.1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cft-k2-OHm">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="version 1.0.0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cft-k2-OHm">
                                 <rect key="frame" x="298.5" y="494" width="99.5" height="24"/>
                                 <fontDescription key="fontDescription" name="Kazesawa-Regular" family="Kazesawa" pointSize="17"/>
                                 <nil key="textColor"/>
@@ -191,6 +191,9 @@
                             <constraint firstItem="0qe-yh-KtP" firstAttribute="trailing" secondItem="bJU-FG-cGu" secondAttribute="trailing" constant="16" id="yZq-pH-YJJ"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="versionLabel" destination="Cft-k2-OHm" id="OPB-Ys-P0v"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CeY-y5-m4r" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/KoarasSimonSaysGame/Pages/Menu/MenuViewController.swift
+++ b/KoarasSimonSaysGame/Pages/Menu/MenuViewController.swift
@@ -11,6 +11,8 @@ import SafariServices
 
 class MenuViewController: UIViewController, UINavigationControllerDelegate {
     
+    @IBOutlet weak var versionLabel: UILabel!
+    
     private var presenter: MenuPresenterInput!
 
     override func viewDidLoad() {
@@ -28,6 +30,10 @@ class MenuViewController: UIViewController, UINavigationControllerDelegate {
         self.navigationController!.navigationBar.setBackgroundImage(UIImage(), for: .default)
         // ナビゲーションバーの影画像（境界線の画像）を空に設定
         self.navigationController!.navigationBar.shadowImage = UIImage()
+        
+        // versionの番号を表示
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
+        versionLabel.text = "version \(version)"
     }
     
     @IBAction func onTapYunyun(_ sender: Any) {

--- a/KoarasSimonSaysGame/Pages/Menu/MenuViewController.swift
+++ b/KoarasSimonSaysGame/Pages/Menu/MenuViewController.swift
@@ -14,7 +14,7 @@ class MenuViewController: UIViewController, UINavigationControllerDelegate {
     @IBOutlet weak var versionLabel: UILabel!
     
     private var presenter: MenuPresenterInput!
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -39,7 +39,7 @@ class MenuViewController: UIViewController, UINavigationControllerDelegate {
     @IBAction func onTapYunyun(_ sender: Any) {
         presenter.didTapYunyunHp()
     }
-
+    
     @IBAction func onTapPrivacyPolicy(_ sender: Any) {
         presenter.didTapPrivacyPolicy()
     }
@@ -63,6 +63,6 @@ class MenuViewController: UIViewController, UINavigationControllerDelegate {
 extension MenuViewController: MenuPresenterOutput {
     func openSafariView(urlString: String) {
         let safariVC = SFSafariViewController(url: NSURL(string: urlString)! as URL)
-            present(safariVC, animated: true, completion: nil)
+        present(safariVC, animated: true, completion: nil)
     }
 }

--- a/KoarasSimonSaysGame/Pages/PlayGame/PlayGamePresenter.swift
+++ b/KoarasSimonSaysGame/Pages/PlayGame/PlayGamePresenter.swift
@@ -79,7 +79,7 @@ class PlayGamePresenter: PlayGamePresenterInput {
 }
 
 extension PlayGamePresenter {
-
+    
     //時間経過の処理
     @objc func timerInterrupt(_ timer: Timer) {
         //経過時間を−1ずつする。
@@ -115,7 +115,7 @@ extension PlayGamePresenter {
     
     //BGMの設定、再生
     private func playMusic() {
-
+        
         do {
             let filePath = Bundle.main.path(forResource: "playBGM",ofType: "mp3")
             let music = URL(fileURLWithPath: filePath!)
@@ -131,7 +131,7 @@ extension PlayGamePresenter {
         timer?.invalidate()
         audioPlayer.stop()
     }
-
+    
     //次の方向指示をランダムで表示させる
     private func proceedToNextDirection() {
         

--- a/KoarasSimonSaysGame/Pages/PlayGame/PlayGameViewController.swift
+++ b/KoarasSimonSaysGame/Pages/PlayGame/PlayGameViewController.swift
@@ -16,8 +16,8 @@ class PlayGameViewController: UIViewController,  UINavigationControllerDelegate 
         
         presenter.viewDidLoad()
     }
-   
-    //--------旗上げゲーム--------
+    
+    // 旗上げゲーム
     @IBAction func upButton(_ sender: Any) {
         presenter.didTapDirectionButton(tappedDirection: .UP)
     }

--- a/KoarasSimonSaysGame/Pages/Ranking/RankingCell.swift
+++ b/KoarasSimonSaysGame/Pages/Ranking/RankingCell.swift
@@ -7,10 +7,10 @@
 //
 
 import UIKit
-    
-class RankingCell: UITableViewCell {
 
-    @IBOutlet weak var rankingNumberLabel: UILabel!   
+class RankingCell: UITableViewCell {
+    
+    @IBOutlet weak var rankingNumberLabel: UILabel!
     @IBOutlet weak var rankingNameLabel: UILabel!
     @IBOutlet weak var rankingScoreLabel: UILabel!
     
@@ -18,10 +18,10 @@ class RankingCell: UITableViewCell {
         super.awakeFromNib()
         // Initialization code
     }
-
+    
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
+        
         // Configure the view for the selected state
     }
 }

--- a/KoarasSimonSaysGame/Pages/Ranking/RankingDataPresenter.swift
+++ b/KoarasSimonSaysGame/Pages/Ranking/RankingDataPresenter.swift
@@ -29,7 +29,7 @@ class RankingDataPresenter {
     
     var isWorldRanking: Bool
     var nameAndScore: [[String]] = []
-        
+    
     private weak var view: RankingDataOutput!
     private let rankingUseCase: RankingUseCase
     
@@ -41,7 +41,7 @@ class RankingDataPresenter {
 }
 
 extension RankingDataPresenter: RankingDataPresenterInput {
-
+    
     func viewDidLoad() {
         if isWorldRanking {
             view.setupWordRanking()

--- a/KoarasSimonSaysGame/Pages/Ranking/RankingDataViewController.swift
+++ b/KoarasSimonSaysGame/Pages/Ranking/RankingDataViewController.swift
@@ -33,7 +33,7 @@ extension RankingDataViewController: UITableViewDelegate, UITableViewDataSource 
     
     //セルの高さ
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-            return 60
+        return 60
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -48,8 +48,8 @@ extension RankingDataViewController: UITableViewDelegate, UITableViewDataSource 
         cell.rankingNumberLabel.text = "\(indexPath.row + 1)位"
         cell.rankingNameLabel.text = "\(nameAndScore[0])"
         cell.rankingScoreLabel.text = "\(nameAndScore[1])点"
-      
-        return cell 
+        
+        return cell
     }
 }
 
@@ -65,7 +65,7 @@ extension RankingDataViewController: UINavigationControllerDelegate {
 }
 
 extension RankingDataViewController {
-
+    
     private func setupView() {
         // タイトルの文字の色設定
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor(red: 89/225, green: 107/225, blue: 179/225, alpha: 1)]
@@ -111,7 +111,7 @@ extension RankingDataViewController: RankingDataOutput {
                                                          preferredStyle: .alert)
         //OKボタン
         let okAction: UIAlertAction = UIAlertAction(title: "OK", style: .default, handler:{
-                    (action:UIAlertAction!) -> Void in
+            (action:UIAlertAction!) -> Void in
             self.presenter.didTapOkOnDeleteAll()
         })
         alert.addAction(okAction)
@@ -133,7 +133,7 @@ extension RankingDataViewController: RankingDataOutput {
         
         //OKボタン
         let okAction: UIAlertAction = UIAlertAction(title: "OK", style: .default, handler:{
-                    (action:UIAlertAction!) -> Void in
+            (action:UIAlertAction!) -> Void in
             // NOP
         })
         alert.addAction(okAction)

--- a/KoarasSimonSaysGame/Pages/ResultPage/RegisterNameViewController.swift
+++ b/KoarasSimonSaysGame/Pages/ResultPage/RegisterNameViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 class RegisterNameViewController: UIViewController {
     
     var presenter: RegisterNamePresenterInput!
-
+    
     @IBOutlet weak var nameTextField: UITextField!
     @IBOutlet weak var registerButton: UIButton!
     @IBOutlet weak var worldRankingSwith: UISwitch!
@@ -19,14 +19,14 @@ class RegisterNameViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-       
+        
         nameTextField.delegate = self
         
         worldRankingSwith.transform = CGAffineTransform(scaleX: 0.7, y: 0.7)
         
         presenter.viewDidLoad()
     }
-   
+    
     @IBAction func onTapRegisterButton(_ sender: Any) {
         presenter.didTapRegisterButton(nameText: nameTextField.text, worldRankingSwith: worldRankingSwith.isOn)
     }

--- a/KoarasSimonSaysGame/Pages/ResultPage/TotalScoreViewController.swift
+++ b/KoarasSimonSaysGame/Pages/ResultPage/TotalScoreViewController.swift
@@ -11,13 +11,13 @@ import UIKit
 class TotalScoreViewController: UIViewController {
     
     var presenter: TotalScorePresenterInput!
-
+    
     @IBOutlet weak var totalScoreLabel: UILabel!
     @IBOutlet weak var messageLabel: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         presenter.viewDidLoad()
         
         //2つ前の画面に戻りたい(直接ゲーム画面には戻さない)ため、navigationvarを消す。

--- a/KoarasSimonSaysGame/Pages/TopPage/ViewController.swift
+++ b/KoarasSimonSaysGame/Pages/TopPage/ViewController.swift
@@ -10,14 +10,14 @@ class ViewController: UIViewController {
         navigationController?.navigationBar.isHidden = true
         
         // 次の画面のBackボタンを「戻る」に変更
-           self.navigationItem.backBarButtonItem = UIBarButtonItem(
-               title:  "戻る",
-               style:  .plain,
-               target: nil,
-               action: nil
-           )
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(
+            title:  "戻る",
+            style:  .plain,
+            target: nil,
+            action: nil
+        )
     }
-
+    
     @IBAction func gameStartButton(_ sender: Any) {
         let storyboard = UIStoryboard(name: "PlayGame", bundle: nil)
         let nextView = storyboard.instantiateViewController(withIdentifier: "gameView") as! PlayGameViewController


### PR DESCRIPTION
## 対応内容
- 前回のリリースしたXcode13対応で修正したものの中で、必要な修正のみチェリーピックした。

## 背景
今回のXcode14対応は、developからブランチを切っていたが、以前のリリースしたXcode13対応のブランチがdevelopにマージされていなかった。<br>今からマージすることはできないため、必要な変更箇所のみチェリーピックしコミットすることにした。

## 修正、変更の詳細内容
以下、前回リリース分(Xcode13対応)の修正
- 使われていない定数を削除する。
- アプリのバージョン情報の表示を、自動で表示が変更されるようにする。
- インデントを合わせる、コメントの修正をする。
- Versionを2.2.0に更新する

## 保留にしたタスク
Xcode13対応時に、develop環境のみプッシュ通知が行えるようにしていたが、プロジェクトのコンフリが多く起きるため、別ブランチで新たに対応した方が良いと判断し、今回は含めなかった。<br>
プッシュ通知は、自己学習のために一旦取り入れたものだったため、必要になった時に対応することにする。

## 懸念点
なし