### PR TITLE
バージョンとビルド番号を更新

### DIFF
--- a/KoarasSimonSaysGame.xcodeproj/project.pbxproj
+++ b/KoarasSimonSaysGame.xcodeproj/project.pbxproj
@@ -1074,7 +1074,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = P2SUKVPCW7;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = P2SUKVPCW7;
 				DISPLAY_NAME = "旗ふりゲーム";
@@ -1084,7 +1084,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yui.KoalasSimonSaysGame;
 				PRODUCT_NAME = "旗ふりゲーム";
 				PROVISIONING_PROFILE_SPECIFIER = KoalasSimonSaysGame;
@@ -1101,7 +1101,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = P2SUKVPCW7;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = P2SUKVPCW7;
 				DISPLAY_NAME = "旗ふりゲーム";
@@ -1111,7 +1111,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yui.KoalasSimonSaysGame;
 				PRODUCT_NAME = "旗ふりゲーム";
 				PROVISIONING_PROFILE_SPECIFIER = KoalasSimonSaysGame;
@@ -1214,7 +1214,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = P2SUKVPCW7;
 				DISPLAY_NAME = "旗ふりゲームDev";
 				INFOPLIST_FILE = KoarasSimonSaysGame/Info.plist;
@@ -1223,7 +1223,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.yui.KoalasSimonSaysGame-DEVELOP";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = KoalasSimonSaysGameDev;
@@ -1239,7 +1239,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = P2SUKVPCW7;
 				DISPLAY_NAME = "旗ふりゲームDev";
 				INFOPLIST_FILE = KoarasSimonSaysGame/Info.plist;
@@ -1248,7 +1248,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.yui.KoalasSimonSaysGame-DEVELOP";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = KoalasSimonSaysGameDev;

--- a/KoarasSimonSaysGame.xcodeproj/project.pbxproj
+++ b/KoarasSimonSaysGame.xcodeproj/project.pbxproj
@@ -1079,6 +1079,8 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = P2SUKVPCW7;
 				DISPLAY_NAME = "旗ふりゲーム";
 				INFOPLIST_FILE = KoarasSimonSaysGame/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "旗ふりゲーム";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1106,6 +1108,8 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = P2SUKVPCW7;
 				DISPLAY_NAME = "旗ふりゲーム";
 				INFOPLIST_FILE = KoarasSimonSaysGame/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "旗ふりゲーム";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1218,6 +1222,8 @@
 				DEVELOPMENT_TEAM = P2SUKVPCW7;
 				DISPLAY_NAME = "旗ふりゲームDev";
 				INFOPLIST_FILE = KoarasSimonSaysGame/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "旗ふりゲームDev";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1243,6 +1249,8 @@
 				DEVELOPMENT_TEAM = P2SUKVPCW7;
 				DISPLAY_NAME = "旗ふりゲームDev";
 				INFOPLIST_FILE = KoarasSimonSaysGame/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "旗ふりゲームDev";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
## 対応内容
- リリースに向けてバージョンとビルド番号を更新

## 修正、変更の詳細内容
- Versionを2.3.0に、Build番号を6に更新する。
- Xcode14よりgeneralの設定が変更されていたため、DisplayNameとApplicationCategoryTypeを設定する。

## 保留にしたタスク
なし

## 懸念点
なし