### PR TITLE
画面のどこかタップすることでkeyboardを閉じれるようにする

### DIFF
--- a/KoarasSimonSaysGame/Pages/ResultPage/RegisterNameViewController.swift
+++ b/KoarasSimonSaysGame/Pages/ResultPage/RegisterNameViewController.swift
@@ -21,6 +21,9 @@ class RegisterNameViewController: UIViewController {
         super.viewDidLoad()
         
         nameTextField.delegate = self
+        // 画面のどこかをタップでTextFiledを閉じる
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(closeKeyboard))
+        self.view.addGestureRecognizer(tapGesture)
         
         worldRankingSwith.transform = CGAffineTransform(scaleX: 0.7, y: 0.7)
         
@@ -41,6 +44,10 @@ extension RegisterNameViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         presenter.textFieldShouldReturn(textField)
         return true
+    }
+    
+    @objc func closeKeyboard() {
+        presenter.textFieldShouldReturn(nameTextField)
     }
 }
 


### PR DESCRIPTION
## 対応内容
- 画面のどこかタップすることでkeyboardを閉じれるようにする。

## 修正、変更の内容詳細
- 画面のどこかをタップした後の挙動は、TextFiledの完了ボタンを押した時と同じ挙動にするためpresenter.textFieldShouldReturn()を呼ぶことにした。

## 保留にしたタスク
なし

## 懸念点
なし